### PR TITLE
Correction to English/Spanish msg files, pt.2

### DIFF
--- a/Fallout_Sonora_1_15_E/master.dat/text/english/dialog/FCSlvStn.msg
+++ b/Fallout_Sonora_1_15_E/master.dat/text/english/dialog/FCSlvStn.msg
@@ -34,7 +34,7 @@
 {228}{}{That's what I thought.}
 {229}{}{Alright. I don't want any trouble.}
 
-// added for the case that the player robs him of the money before asking for it - cambragol
+# added for the case that the player robs him of the money before asking for it - cambragol
 {230}{}{What!? I never asked for that shit. Besides, someone robbed me blind. I'm broke.}
 {231}{}{For some reason I believe you. Consider yourself lucky.}
 

--- a/Fallout_Sonora_1_15_E/master.dat/text/english/dialog/GCBrmAtk.msg
+++ b/Fallout_Sonora_1_15_E/master.dat/text/english/dialog/GCBrmAtk.msg
@@ -44,6 +44,6 @@
 {258}{}{See you in Garage City.}
 {259}{}{We've almost got the brahmin. Wait until I bring it closer...}
 
-// added this to have better responses for buying the brahmin - cambragol
+# added this to have better responses for buying the brahmin - cambragol
 {260}{}{I traded with the herders for the Brahmin. It's ours now.}
 

--- a/Fallout_Sonora_1_15_E/master.dat/text/english/dialog/GCMotel.msg
+++ b/Fallout_Sonora_1_15_E/master.dat/text/english/dialog/GCMotel.msg
@@ -2,7 +2,7 @@
 {101}{}{You see a short, bald man in very worn clothes.}
 {102}{}{You are well rested and energized.}
 
-Reaction to armor
+#Reaction to armor
 {160}{}{That's quite the outfit you have. Maybe a tad too much. Selling?}
 {161}{}{It's not for sale. It's a family heirloom.}
 {162}{}{(purses lips thoughtfully) Hmm. An affinity for old stuff must be in your blood.}
@@ -43,7 +43,7 @@ Reaction to armor
 {198}{}{I highly doubt it.}
 {199}{}{Let's not fight. I am here for peaceful purposes.}
 
-First dialogue
+#First dialogue
 {200}{}{(You see a balding man in a shabby jacket; he peers at you suspiciously through the gloom of the stuffy motel lobby.)}
 {201}{}{Hello.}
 {202}{}{Hey hey! Those guys were just hooligans. I didn't want any problems and turned a blind eye to their antics. What was I to do? I'm also a victim of circumstances. But killing them... Let's just say I didn't see anything, and you just leave, okay?}

--- a/Fallout_Sonora_1_15_E/master.dat/text/english/dialog/ISCompB.msg
+++ b/Fallout_Sonora_1_15_E/master.dat/text/english/dialog/ISCompB.msg
@@ -1,7 +1,7 @@
 {100}{}{You see a computer.}
 {101}{}{You see an ancient computer. It's remarkable that it still functions.}
 
-**#Dialogue**
+# Dialogue
 {200}{}{System loaded}
 {201}{}{End session}
 {202}{}{Back}

--- a/Fallout_Sonora_1_15_E/master.dat/text/english/dialog/NCSilosA.msg
+++ b/Fallout_Sonora_1_15_E/master.dat/text/english/dialog/NCSilosA.msg
@@ -10,7 +10,7 @@
 {205}{}{It's time for me to go.}
 {206}{}{I see.}
 
-{207}{}{How can I help you?} // added this to make the dialogue smoother - cambragol
+{207}{}{How can I help you?} # added this to make the dialogue smoother - cambragol
 
 
 {210}{}{How much do you pay your workers?}

--- a/Fallout_Sonora_1_15_E/master.dat/text/english/dialog/NSCmpLab.msg
+++ b/Fallout_Sonora_1_15_E/master.dat/text/english/dialog/NSCmpLab.msg
@@ -3,8 +3,7 @@
 {102}{}{The computer won't start due to lack of power.}
 {103}{}{It won't turn on.}
 
-Dialogue
-
+# Dialogue
 {200}{}{Enter command:}
 {201}{}{End session}
 {202}{}{Back}

--- a/Fallout_Sonora_1_15_E/master.dat/text/english/dialog/PCMaster.msg
+++ b/Fallout_Sonora_1_15_E/master.dat/text/english/dialog/PCMaster.msg
@@ -368,8 +368,8 @@
 {590}{}{You haven't really deemed that many people to be 'worthy' either, have you?}
 
 #Quest enhancement by cambragol
-{591}{}{Yes, the acolytes routines' may have been leaked. Matthias seems to have been checking their schedules recently...}
-{592}{}{Yes, the acolytes routines' may have been leaked. Matthias seems to have been using the radio to communicate with someone outside the cathedral...}
+{591}{}{Yes, the acolytes' routines may have been leaked. Matthias seems to have been checking their schedules recently...}
+{592}{}{Yes, the acolytes' routines may have been leaked. Matthias seems to have been using the radio to communicate with someone outside the cathedral...}
 {593}{}{Matthias? Are you insane? He is one of my most trusted advisors. Look elsewhere, fool.}
 {594}{}{Uh, yes, of course my Lord.}
 

--- a/Fallout_Sonora_1_15_E/master.dat/text/english/dialog/PSAtmCmp.msg
+++ b/Fallout_Sonora_1_15_E/master.dat/text/english/dialog/PSAtmCmp.msg
@@ -1,7 +1,7 @@
 {100}{}{You see a computer.}
 {101}{}{You see a decrepit terminal, barely functional but still clinging to the public network.}
 
-Dialogue
+# Dialogue
 {200}{}{Enter command.}
 {201}{}{End session.}
 {202}{}{Go back.}

--- a/Fallout_Sonora_1_15_E/master.dat/text/english/dialog/RCComndr.msg
+++ b/Fallout_Sonora_1_15_E/master.dat/text/english/dialog/RCComndr.msg
@@ -168,7 +168,7 @@
 {364}{}{Glad to be of service.}
 {1364}{}{Glad to be of service.}
 {365}{}{Here's to future cooperation.}
-// added by cambragol for mid-way feedback
+# added by cambragol for mid-way feedback
 {366}{}{Radio's nearly fixed. Just working on possible interference with the signal.}
 {367}{}{Report back when it's done.}
 {368}{}{Got it.}

--- a/Fallout_Sonora_1_15_E/master.dat/text/english/dialog/RCRngMap.msg
+++ b/Fallout_Sonora_1_15_E/master.dat/text/english/dialog/RCRngMap.msg
@@ -27,7 +27,7 @@
 {233}{}{Why haven't you left?}
 {234}{}{Despite the command center being in ruins, it doesn't absolve me of my duties.}
 
-- added below for mid-quest help in survey quest and map reward for same quest - cambragol
+# added below for mid-quest help in survey quest and map reward for same quest - cambragol
 {235}{}{So where are these survey markers?}
 {236}{}{Like I said, they're like a tripod of metal and junk, stuck into an old tire.}
 {237}{}{Alright, I'll keep at it.}

--- a/Fallout_Sonora_1_15_E/master.dat/text/english/dialog/VCOld.msg
+++ b/Fallout_Sonora_1_15_E/master.dat/text/english/dialog/VCOld.msg
@@ -15,9 +15,10 @@
 {204}{}{Look, if you stop chewing that tobacco, I might actually hear what you're saying.}
 {205}{}{(He spits and wipes his mouth with a bony hand.) I'm saying... the community wants you at the gathering. We figured it's time for you to throw in your two cents.}
 {206}{}{What gathering?}
-{207}{}{The community's gotta decide what to do next. Saving our folks wasn't the end of our troubles.}
-{208}{}{When's the meeting?}
-{209}{}{This evening, once everyone's finished their chores and gathered in the hall. Us old folks don't rush things, so count on it taking all night.}
+{207}{}{We got decisions to make. Savin' our people ain't the end of our struggles, amigo.}
+{1207}{}{We got decisions to make. Savin' our people ain't the end of our struggles, amiga.}
+{208}{}{When's the gathering?}
+{209}{}{Tonight, when the sun's down and the day's work is done. We old-timers like to take our time, so don't expect it to wrap up quick.}
 {210}{}{I'll be there on time. See you then.}
 {211}{}{Alright, I'll make sure to be there.}
 {212}{}{Might as well wait here. How about a game of dice to kill the time?}

--- a/Fallout_Sonora_1_15_E/master.dat/text/english/game/INTRFACE.MSG
+++ b/Fallout_Sonora_1_15_E/master.dat/text/english/game/INTRFACE.MSG
@@ -6,4 +6,4 @@
 {102}{}{ADDICT}
 {103}{}{POISONED}
 {104}{}{RADIATED}
-{105}{}{CRIPPLED}//added for sfall -cambragol
+{105}{}{CRIPPLED} # added for sfall -cambragol

--- a/Fallout_Sonora_1_15_E/master.dat/text/english/game/PERK.MSG
+++ b/Fallout_Sonora_1_15_E/master.dat/text/english/game/PERK.MSG
@@ -97,7 +97,7 @@
 {193}{}{Here and Now}
 {194}{}{Block Strike} # changed
 {195}{}{Sonoran Expert}
-{196}{}{Hollywood Karma}*** what to do...
+{196}{}{Hollywood Karma} # what to do...
 {197}{}{Light Step}
 {198}{}{Living Anatomy}
 {199}{}{Intimidation} # changed

--- a/Fallout_Sonora_1_15_E/master.dat/text/english/game/WORLDMAP.MSG
+++ b/Fallout_Sonora_1_15_E/master.dat/text/english/game/WORLDMAP.MSG
@@ -1,11 +1,11 @@
-################################################## #####
+#######################################################
 #
 # Names of areas for the location loading window
 #
-################################################## #####
+#######################################################
 
 
-#Villa 
+# Villa
 {200}{}{Residential Area}
 {201}{}{Plaza de la Sombra}
 {202}{}{Villa Cellars}
@@ -45,12 +45,12 @@
 {244}{}{Ambush Site}
 {245}{}{Old Town}
 #
-# Puerto Penasco 
+# Puerto Penasco
 {250}{}{Main Street}
 {251}{}{Old Port}
 {252}{}{Brotherhood of Steel Base}
 #
-#Rangers 
+# Rangers
 {260}{}{Road to the Dam}
 {261}{}{Dam}
 {262}{}{Aqueduct}
@@ -60,7 +60,7 @@
 {266}{}{Giers Wash}
 {267}{}{Citadel}
 #
-#Phoenix 
+# Phoenix
 {270}{}{City Gate}
 {271}{}{Downtown}
 {272}{}{Slums}
@@ -79,7 +79,7 @@
 {283}{}{Oil Platform}
 {284}{}{Black Lagoon}
 #
-#CasaGrande
+# Casa Grande
 {290}{}{Water Pump}
 {291}{}{Mansion}
 {292}{}{Graveyard}
@@ -115,7 +115,7 @@
 #! Empty slot
 {340}{}{Desert}
 #
-#DeadMotel 
+# Dead Motel
 {350}{}{Old Motel}
 #
 # Dayglow DLC
@@ -134,12 +134,12 @@
 # ! Empty slot
 #{370}{}{Desert}
 #
-# SantaAna
+# Santa Ana
 {380}{}{Plaza Zaragoza}
 {381}{}{Ancient Monument}
 {382}{}{Ancient Cemetery}
 #
-#! Empty slot
+# ! Empty slot
 {390}{}{Desert}
 #
 # Jackals
@@ -202,43 +202,43 @@
 # Explosion crater in Puerto
 {500}{}{Blast Epicenter}
 #
-# Special Encounter- Gold
+# Special Encounter - Gold
 {510}{}{Sonoran Wasteland}
 #
-# Special Encounter- Henry Bemis
+# Special Encounter - Henry Bemis
 {520}{}{Sonoran Wasteland}
 #
-# Special Encounter- Roadside Cafe
+# Special Encounter - Roadside Cafe
 {530}{}{Sonoran Wasteland}
 #
-# Special Encounter- Bomber
+# Special Encounter - Bomber
 {540}{}{Sonoran Wasteland}
 #
-# Special Encounter- Petro-Chico Truck
+# Special Encounter - Petro-Chico Truck
 {550}{}{Sonoran Wasteland}
 #
-# Special Encounter- Scream of Silence
+# Special Encounter - Scream of Silence
 {560}{}{Sonoran Wasteland}
 #
-# Special Encounter- Night movie screening
+# Special Encounter - Night movie screening
 {570}{}{Sonoran Wasteland}
 #
-# Special Encounter- Padre
+# Special Encounter - Padre
 {580}{}{Sonoran Wasteland}
 #
-# Special Encounter- Baron of Arizona
+# Special Encounter - Baron of Arizona
 {590}{}{Sonoran Wasteland}
 #
-# Special Encounter- Snowfall
+# Special Encounter - Snowfall
 {600}{}{Sonoran Wasteland}
 #
-# Special Encounter- Lost Sanctuary (Van Buren)
+# Special Encounter - Lost Vault (Van Buren)
 {610}{}{Sonoran Wasteland}
 #
-# Special Encounter- Mobile fortress of the Master's army
+# Special Encounter - Mobile fortress of the Master's army
 {620}{}{Sonoran Wasteland}
 #
-# Special Encounter- Rail Nomads
+# Special Encounter - Rail Nomads
 {630}{}{Sonoran Wasteland}
 #
 #! Empty slot
@@ -266,11 +266,11 @@
 {680}{}{Camp in the Mountains}
 
 
-################################################## #####
+#######################################################
 #
 # Miscellaneous
 #
-################################################## #####
+#######################################################
 
 # Signature when hovering over the GG marker (does not work, a rudiment of Fallout 1):
 {1000}{}{Desert}
@@ -288,16 +288,16 @@
 {1503}{}{This is a motorcycle. Apparently it doesn't work.}
 
 
-################################################## #####
+#######################################################
 #
 # Description of encounters on the world map
 #
-################################################## #####
+#######################################################
 
 {2998}{}{You encounter:}
 {2999}{}{Do you wish to encounter:}
 
-# Encounter Table 0-- TEST_D
+# Encounter Table 0 -- TEST_D
 {3000}{}{A Red Rider.}
 {3001}{}{Rockfall!}
 {3002}{}{Radioactive fog!}
@@ -330,7 +330,7 @@
 {3029}{}{A Mobile Fortress.}
 {3030}{}{Legend City.}
 
-# Encounter Table 1-- VILL_D
+# Encounter Table 1 -- VILL_D
 {3050}{}{Some giant ants.}
 {3051}{}{A pack of coyotes.}
 {3052}{}{A pack of pig rats.}
@@ -349,7 +349,7 @@
 {3065}{}{A Mobile Fortress.}
 {3066}{}{Legend City.}
 
-# Encounter Table 2-- FLAG_D
+# Encounter Table 2 -- FLAG_D
 {3100}{}{A Red Rider.}
 {3101}{}{A pack of pig rats.}
 {3102}{}{A pack of wolves.}
@@ -370,7 +370,7 @@
 {3117}{}{A Mobile Fortress.}
 {3118}{}{Legend City.}
 
-# Encounter Table 3-- FLAG_M
+# Encounter Table 3 -- FLAG_M
 {3150}{}{A Red Rider.}
 {3151}{}{Rockfall!}
 {3152}{}{A pack of mole rats.}
@@ -388,7 +388,7 @@
 {3164}{}{The Lost Vault.}
 {3165}{}{Legend City.}
 
-# Encounter Table 4-- FLAG_R
+# Encounter Table 4 -- FLAG_R
 {3200}{}{A Red Rider.}
 {3201}{}{A pack of pig rats.}
 {3202}{}{A band of highwaymen.}
@@ -398,7 +398,7 @@
 {3206}{}{A group of colonizers.}
 {3207}{}{A pack of stray dogs.}
 
-# Encounter Table 5-- RNGR_D
+# Encounter Table 5 -- RNGR_D
 {3250}{}{A Red Rider.}
 {3251}{}{A dust storm!}
 {3252}{}{A pack of coyotes.}
@@ -423,7 +423,7 @@
 {3271}{}{The terrible monster La Fantasma!}
 {3272}{}{Dehydration!}
 
-# Encounter Table 6-- DSRT_A
+# Encounter Table 6 -- DSRT_A
 {3300}{}{A dust storm!}
 {3301}{}{Dehydration!}
 {3302}{}{A pack of radscorpions.}
@@ -441,7 +441,7 @@
 {3314}{}{A Mobile Fortress.}
 {3315}{}{Legend City.}
 
-# Encounter Table 7-- DSRT_B
+# Encounter Table 7 -- DSRT_B
 {3350}{}{A dust storm!}
 {3351}{}{Dehydration!}
 {3352}{}{A pack of radscorpions.}
@@ -461,7 +461,7 @@
 {3366}{}{Legend City.}
 {3367}{}{A wrecked car.}
 
-# Encounter Table 8-- MEXI_D
+# Encounter Table 8 -- MEXI_D
 {3400}{}{A Red Rider.}
 {3401}{}{A pack of radscorpions.}
 {3402}{}{A swarm of Mantises.}
@@ -483,7 +483,7 @@
 {3418}{}{Legend City.}
 {3419}{}{A Mexican running from a centipede.}
 
-# Encounter Table 9-- MEXI_M
+# Encounter Table 9 -- MEXI_M
 {3450}{}{Red Rider.}
 {3451}{}{Rockfall!}
 {3452}{}{A pack of mole rats.}
@@ -501,7 +501,7 @@
 {3464}{}{Legend City.}
 {3465}{}{A carnivorous brahmin.}
 
-# Encounter Table 10-- CALF_D
+# Encounter Table 10 -- CALF_D
 {3500}{}{A Red Rider.}
 {3501}{}{Radioactive fog!}
 {3502}{}{A pack of rats.}
@@ -520,7 +520,7 @@
 {3515}{}{A Mobile Fortress.}
 {3516}{}{Legend City.}
 
-# Encounter Table 11-- PHNX_D
+# Encounter Table 11 -- PHNX_D
 {3550}{}{A Red Rider.}
 {3551}{}{A pack of rats.}
 {3552}{}{A pack of stray dogs.}
@@ -536,14 +536,14 @@
 {3562}{}{The Lost Vault.}
 {3563}{}{Legend City.}
 
-# Encounter Table 12-- PHNX_M
+# Encounter Table 12 -- PHNX_M
 {3600}{}{Radioactive fog!}
 {3601}{}{A group of giant ants.}
 {3602}{}{The body of an unlucky marauder.}
 {3603}{}{A lonely scavenger.}
 {3604}{}{A pissed off Mr. Handy.}
 
-# Encounter Table 13-- ROAD_D
+# Encounter Table 13 -- ROAD_D
 {3650}{}{A Red Rider.}
 {3651}{}{A body abandoned on the road.}
 {3652}{}{A pack of rats.}
@@ -557,7 +557,7 @@
 {3660}{}{The Lost Vault.}
 {3661}{}{Legend City.}
 
-# Encounter Table 14-- TUSN_D
+# Encounter Table 14 -- TUSN_D
 {3700}{}{A Red Rider.}
 {3701}{}{A pack of rats.}
 {3702}{}{A pack of radscorpions.}
@@ -567,7 +567,7 @@
 {3706}{}{The corpse of a runaway slave.}
 {3707}{}{A cyborg.}
 
-# Encounter Table 15-- TUSN_M
+# Encounter Table 15 -- TUSN_M
 {3750}{}{Rockfall!}
 {3751}{}{A pack of mole rats.}
 {3752}{}{A pack of wolves.}
@@ -584,7 +584,7 @@
 {3763}{}{The Lost Vault.}
 {3764}{}{Legend City.}
 
-# Encounter Table 16-- INFN_D
+# Encounter Table 16 -- INFN_D
 {3800}{}{Radioactive fog!}
 {3801}{}{A group of giant ants.}
 {3802}{}{A slew of scavengers.}
@@ -592,7 +592,7 @@
 {3804}{}{A USP agent.}
 {3805}{}{Harvey.}
 
-# Encounter Table 17-- PORT_D
+# Encounter Table 17 -- PORT_D
 {3850}{}{A Red Rider.}
 {3851}{}{Dehydration!}
 {3852}{}{Some giant ants.}
@@ -600,7 +600,7 @@
 {3854}{}{A pack of radscorpions.}
 {3855}{}{A Brotherhood of Steel Patrol.}
 
-# Encounter Table 18-- ISLD_D
+# Encounter Table 18 -- ISLD_D
 {3900}{}{A group of giant ants exploring the coast.}
 {3901}{}{A monster.}
 {3902}{}{A body washed ashore.}
@@ -608,7 +608,7 @@
 {3904}{}{The body of a scout.}
 {3905}{}{Some raiders torturing a clerk.}
 
-# Encounter Table 19-- ISLD_M
+# Encounter Table 19 -- ISLD_M
 {3950}{}{Rockfall!}
 {3951}{}{Radioactive fog!}
 {3952}{}{A group of giant ants.}
@@ -625,5 +625,5 @@
 {3963}{}{A flying Padre.}
 {3964}{}{Legend City.}
 
-# Encounter Table 20-- OCEAN_O
+# Encounter Table 20 -- OCEAN_O
 {4000}{}{Radioactive fog!}

--- a/Fallout_Sonora_1_15_E/master.dat/text/spanish/dialog/FCSlvStn.msg
+++ b/Fallout_Sonora_1_15_E/master.dat/text/spanish/dialog/FCSlvStn.msg
@@ -34,7 +34,7 @@
 {228}{}{Muy bien hecho.}
 {229}{}{Está bien, no quiero problemas.}
 
-// added for the case that the player robs him of the money before asking for it - cambragol
+# added for the case that the player robs him of the money before asking for it - cambragol
 {230}{}{¿¡Qué!? No sé por qué te importa. Además, alguien robó mis chapas. Estoy quebrado.}
 {231}{}{Por alguna razón, te creo. Tuviste suerte.}
 

--- a/Fallout_Sonora_1_15_E/master.dat/text/spanish/dialog/GCBrmAtk.msg
+++ b/Fallout_Sonora_1_15_E/master.dat/text/spanish/dialog/GCBrmAtk.msg
@@ -44,6 +44,6 @@
 {258}{}{Nos vemos en Ciudad Garaje.}
 {259}{}{Ya casi tenemos al brahmán. Espera a que lo acerque un poco más...}
 
-// added this to have better responses for buying the brahmin - cambragol
+# added this to have better responses for buying the brahmin - cambragol
 {260}{}{Pude llegar a un acuerdo por el brahmán. Ahora es nuestro.}
 

--- a/Fallout_Sonora_1_15_E/master.dat/text/spanish/dialog/GCMotel.msg
+++ b/Fallout_Sonora_1_15_E/master.dat/text/spanish/dialog/GCMotel.msg
@@ -2,7 +2,7 @@
 {101}{}{Estás viendo a un hombre bajo y calvo con ropa muy desgastada.}
 {102}{}{Has descansado bien, te sientes con energía.}
 
-Reaction to armor
+#Reaction to armor
 {160}{}{Que bonito traje tienes, hasta diría que es demasiado. ¿Lo vendes?}
 {161}{}{No está a la venta. Es una reliquia familiar.}
 {162}{}{(frunce los labios, pensativo) Hmm. Parece que en tu sangre corre una afinidad por las cosas viejas.}
@@ -43,7 +43,7 @@ Reaction to armor
 {198}{}{Lo dudo mucho.}
 {199}{}{No peleemos, vengo en son de paz.}
 
-First dialogue
+#First dialogue
 {200}{}{(Estás viendo a un hombre calvo de chaqueta raída; te mira con suspicacia a través de la penumbra del vestíbulo del motel, el cual está mal ventilado.)}
 {201}{}{Hola.}
 {202}{}{¡Oye, oye! Esos tipos eran unos vándalos, no quería problemas y por eso ignoraba sus actos. ¿Qué iba a hacer? Yo también soy una víctima de mi situación. Pero, los mataste... Hagamos esto. Yo no vi nada y tú te irás. ¿Bien?}

--- a/Fallout_Sonora_1_15_E/master.dat/text/spanish/dialog/ISCompB.msg
+++ b/Fallout_Sonora_1_15_E/master.dat/text/spanish/dialog/ISCompB.msg
@@ -1,7 +1,7 @@
 {100}{}{Ves una computadora.}
 {101}{}{Estás viendo una antigua computadora. Es sorprendente que siga funcionando.}
 
-**#Dialogue**
+# Dialogue
 {200}{}{Se ha cargado el sistema.}
 {201}{}{Cerrar sesión}
 {202}{}{Regresar}

--- a/Fallout_Sonora_1_15_E/master.dat/text/spanish/dialog/NCSilosA.msg
+++ b/Fallout_Sonora_1_15_E/master.dat/text/spanish/dialog/NCSilosA.msg
@@ -10,7 +10,7 @@
 {205}{}{Tengo que irme.}
 {206}{}{Ya veo.}
 
-{207}{}{¿Te ayudo en algo?} // added this to make the dialogue smoother - cambragol
+{207}{}{¿Te ayudo en algo?} # added this to make the dialogue smoother - cambragol
 
 
 {210}{}{¿Cuánto le pagas a los trabajadores?}

--- a/Fallout_Sonora_1_15_E/master.dat/text/spanish/dialog/NSCmpLab.msg
+++ b/Fallout_Sonora_1_15_E/master.dat/text/spanish/dialog/NSCmpLab.msg
@@ -3,8 +3,7 @@
 {102}{}{La computadora no enciende por la falta de energía.}
 {103}{}{No enciende.}
 
-Dialogue
-
+# Dialogue
 {200}{}{Introducir comando:}
 {201}{}{Cerrar sesión}
 {202}{}{Regresar}

--- a/Fallout_Sonora_1_15_E/master.dat/text/spanish/dialog/PSAtmCmp.msg
+++ b/Fallout_Sonora_1_15_E/master.dat/text/spanish/dialog/PSAtmCmp.msg
@@ -1,7 +1,7 @@
 {100}{}{Ves una computadora.}
 {101}{}{Ves una computadora viejísima, apenas funciona, pero sigue conectada a la red pública.}
 
-Dialogue
+# Dialogue
 {200}{}{Introducir comando.}
 {201}{}{Cerrar sesión.}
 {202}{}{Regresar.}

--- a/Fallout_Sonora_1_15_E/master.dat/text/spanish/dialog/RCComndr.msg
+++ b/Fallout_Sonora_1_15_E/master.dat/text/spanish/dialog/RCComndr.msg
@@ -168,7 +168,7 @@
 {364}{}{A su servicio.}
 {1364}{}{A su servicio.}
 {365}{}{Espero que podamos seguir cooperando en el futuro.}
-// added by cambragol for mid-way feedback
+# added by cambragol for mid-way feedback
 {366}{}{Ya casi arreglo la radio, pero hay algo de interferencia en la señal y estoy trabajando en ello.}
 {367}{}{Una vez que hayas terminado, házmelo saber. Quizás debas rastrear la frecuencia, de alguna forma.}
 {368}{}{Vale.}

--- a/Fallout_Sonora_1_15_E/master.dat/text/spanish/dialog/RCRngMap.msg
+++ b/Fallout_Sonora_1_15_E/master.dat/text/spanish/dialog/RCRngMap.msg
@@ -27,7 +27,7 @@
 {233}{}{¿Por qué no te has ido de aquí?}
 {234}{}{A pesar de que el centro de mando esté en ruinas, eso no me absuelve de mi deber.}
 
-- added below for mid-quest help in survey quest and map reward for same quest - cambragol
+# added below for mid-quest help in survey quest and map reward for same quest - cambragol
 {235}{}{¿En dónde están los marcadores topográficos?}
 {236}{}{Como dije, son un trípode de madera y chatarra, insertados en un neumático viejo.}
 {237}{}{Entiendo, iré a buscarlos.}

--- a/Fallout_Sonora_1_15_E/master.dat/text/spanish/game/COMBATAI.MSG
+++ b/Fallout_Sonora_1_15_E/master.dat/text/spanish/game/COMBATAI.MSG
@@ -2857,7 +2857,7 @@
 {14179}{}{Estás buscando problemas.}
 
 ############################################
-15000 Bos (knight)
+# 15000 Bos (knight)
 ############################################
 #
 #HIT IN HEAD
@@ -3969,7 +3969,7 @@
 {21146}{}{*¡Chillido!*}
 {21147}{}{*¡Chillido!*}
 {21148}{}{*¡Chillido-chillido!*}
-{21149}{}{*¡Chillido! ¡Chillido!}*
+{21149}{}{*¡Chillido! ¡Chillido!*}
 #
 #  TARGET BEING MISSED
 #

--- a/Fallout_Sonora_1_15_E/master.dat/text/spanish/game/INTRFACE.MSG
+++ b/Fallout_Sonora_1_15_E/master.dat/text/spanish/game/INTRFACE.MSG
@@ -6,4 +6,4 @@
 {102}{}{ADICTO}
 {103}{}{ENVENENADO}
 {104}{}{IRRADIADO}
-{105}{}{FRACTURA}//added for sfall -cambragol
+{105}{}{FRACTURA} # added for sfall -cambragol

--- a/Fallout_Sonora_1_15_E/master.dat/text/spanish/game/PERK.MSG
+++ b/Fallout_Sonora_1_15_E/master.dat/text/spanish/game/PERK.MSG
@@ -97,7 +97,7 @@
 {193}{}{Aquí y ahora}
 {194}{}{Bloqueo Melee} # changed
 {195}{}{Experto Sonorense}
-{196}{}{Karma resplandeciente}*** what to do...
+{196}{}{Karma resplandeciente} # what to do...
 {197}{}{Paso ligero}
 {198}{}{Anatomía vital}
 {199}{}{Intimidación} # changed

--- a/Fallout_Sonora_1_15_E/master.dat/text/spanish/game/WORLDMAP.MSG
+++ b/Fallout_Sonora_1_15_E/master.dat/text/spanish/game/WORLDMAP.MSG
@@ -1,11 +1,11 @@
-#
-# 
+#######################################################
 #
 # Etiquetas de texto y mensajes usados para ciudad y mapa del mundo
 #
-# ?
+#######################################################
 
-#Villa
+
+# Villa
 {200}{}{Area Residencial}
 {201}{}{Plaza de la Sombra}
 {202}{}{Sotano de la Villa}
@@ -50,7 +50,7 @@
 {251}{}{Puerto}
 {252}{}{Base de la Hermandad}
 #
-#Rangers
+# Rangers
 {260}{}{Camino a la Presa}
 {261}{}{Presa}
 {262}{}{Acueducto}
@@ -60,7 +60,7 @@
 {266}{}{Giers Wash}
 {267}{}{Ciudadela}
 #
-#Phoenix
+# Phoenix
 {270}{}{Puerta de la Ciudad}
 {271}{}{Centro}
 {272}{}{Barrios bajos}
@@ -79,7 +79,7 @@
 {283}{}{Plataforma petrolifera}
 {284}{}{Laguna Negra}
 #
-#CasaGrande
+# Casa Grande
 {290}{}{Bomba de Agua}
 {291}{}{Mansion}
 {292}{}{Cementerio}
@@ -92,7 +92,7 @@
 {301}{}{Guarnicion}
 {302}{}{Fuerte}
 #
-# San Felipe ( Old Lighthouse )
+# San Felipe (Old Lighthouse)
 {310}{}{Asentamiento del Faro}
 {311}{}{Fondeport}
 {312}{}{Cerro Picacho del Diablo}
@@ -115,7 +115,7 @@
 #! Empty slot
 {340}{}{Desierto}
 #
-#DeadMotel
+# Dead Motel
 {350}{}{Motel Viejo}
 #
 # Dayglow DLC
@@ -131,15 +131,15 @@
 {369}{}{Refugio 24}
 {370}{}{Base Naval EE.UU}
 #
-#! Empty slot
+# ! Empty slot
 {370}{}{Desierto}
 #
-# SantaAna
+# Santa Ana
 {380}{}{Plaza Zaragoza}
 {381}{}{Monumento Antiguo}
 {382}{}{Cementerio Antiguo}
 #
-#! Empty slot
+# ! Empty slot
 {390}{}{Desierto}
 #
 # Jackals
@@ -148,7 +148,7 @@
 # Motorcycle without energy
 {410}{}{Motocicleta sin combustible}
 #
-# Destroyed Arroyo ( do not use!)
+# Destroyed Arroyo (do not use!)
 {420}{}{Desierto}
 #
 # Vault 27
@@ -202,43 +202,43 @@
 # Explosion crater in Puerto
 {500}{}{Centro de la Explosión}
 #
-# Special Encounter- Gold
+# Special Encounter - Gold
 {510}{}{Yermo Sonorense}
 #
-# Special Encounter- Henry Bemis
+# Special Encounter - Henry Bemis
 {520}{}{Yermo Sonorense}
 #
-# Special Encounter- Roadside Cafe
+# Special Encounter - Roadside Cafe
 {530}{}{Yermo Sonorense}
 #
-# Special Encounter- Bomber
+# Special Encounter - Bomber
 {540}{}{Yermo Sonorense}
 #
-# Special Encounter- Petro-Chico Truck
+# Special Encounter - Petro-Chico Truck
 {550}{}{Yermo Sonorense}
 #
-# Special Encounter- Scream of Silence
+# Special Encounter - Scream of Silence
 {560}{}{Yermo Sonorense}
 #
-# Special Encounter- Night movie screening
+# Special Encounter - Night movie screening
 {570}{}{Yermo Sonorense}
 #
-# Special Encounter- Padre
+# Special Encounter - Padre
 {580}{}{Yermo Sonorense}
 #
-# Special Encounter- Baron of Arizona
+# Special Encounter - Baron of Arizona
 {590}{}{Yermo Sonorense}
 #
-# Special Encounter- Snowfall
+# Special Encounter - Snowfall
 {600}{}{Yermo Sonorense}
 #
-# Special Encounter- Lost Sanctuary ( Van Buren )
+# Special Encounter - Lost Vault (Van Buren)
 {610}{}{Yermo Sonorense}
 #
-# Special Encounter- Mobile fortress of the Master's army
+# Special Encounter - Mobile fortress of the Master's army
 {620}{}{Yermo Sonorense}
 #
-# Special Encounter- Rail Nomads
+# Special Encounter - Rail Nomads
 {630}{}{Yermo Sonorense}
 #
 #! Empty slot
@@ -247,7 +247,7 @@
 #! Empty slot
 {650}{}{Yermo Sonorense}
 #
-# Irradiated Village ( Quartzsite )
+# Irradiated Village (Quartzsite)
 {660}{}{Ruinas de Quartzsite}
 #
 #ShadowWorlds
@@ -266,38 +266,38 @@
 {680}{}{Campamento en las Montañas}
 
 
-################################################## #####
+#######################################################
 #
 # Miscellaneous
 #
-################################################## #####
+#######################################################
 
-# Signature when hovering over the GG marker ( does not work , a rudiment of Fallout 1):
+# Signature when hovering over the GG marker (does not work, a rudiment of Fallout 1):
 {1000}{}{Desierto}
 {1001}{}{Montes}
 {1002}{}{Ciudad}
 {1003}{}{Costa}
 
-# Signature of a location not yet explored :
+# Signature of a location not yet explored:
 {1004}{}{Desconocido}
 
-# Miscellaneous :
+# Miscellaneous:
 {1500}{}{Has ganado 10.000 puntos de experiencia.}
 {1501}{}{Ruinas}
 {1502}{}{La motocicleta ya no tiene combustible.}
 {1503}{}{Es una motocicleta. No parece que que pueda ponerse en marcha.}
 
 
-################################################## #####
+#######################################################
 #
 # Description of encounters on the world map
 #
-################################################## #####
+#######################################################
 
 {2998}{}{Encuentras:}
 {2999}{}{¿Deseas tropezarte con este encuentro?:}
 
-# Encounter Table 0-- TEST_D
+# Encounter Table 0 -- TEST_D
 {3000}{}{Red Ryder.}
 {3001}{}{Un derrumbe}
 {3002}{}{Niebla radiactiva}
@@ -330,7 +330,7 @@
 {3029}{}{Una fortaleza movil.}
 {3030}{}{Legend City.}
 
-# Encounter Table 1-- VILL_D
+# Encounter Table 1 -- VILL_D
 {3050}{}{Algunas hormigas gigantes.}
 {3051}{}{Una manada de coyotes.}
 {3052}{}{Una manada de ratas cerdo.}
@@ -349,7 +349,7 @@
 {3065}{}{Una fortaleza movil.}
 {3066}{}{Legend City.}
 
-# Encounter Table 2-- FLAG_D
+# Encounter Table 2 -- FLAG_D
 {3100}{}{Red Ryder.}
 {3101}{}{Una manada de ratas cerdo.}
 {3102}{}{Una manada de lobos.}
@@ -370,7 +370,7 @@
 {3117}{}{Una fortaleza movil.}
 {3118}{}{Legend City.}
 
-# Encounter Table 3-- FLAG_M
+# Encounter Table 3 -- FLAG_M
 {3150}{}{Red Ryder.}
 {3151}{}{Un derrumbe}
 {3152}{}{Una manada de ratas topo.}
@@ -388,7 +388,7 @@
 {3164}{}{El Santuario Perdido.}
 {3165}{}{Legend City.}
 
-# Encounter Table 4-- FLAG_R
+# Encounter Table 4 -- FLAG_R
 {3200}{}{Red Ryder.}
 {3201}{}{Una manada de ratas cerdo.}
 {3202}{}{Una banda de forajidos.}
@@ -398,7 +398,7 @@
 {3206}{}{Un grupo de colonizadores.}
 {3207}{}{Una manada de perros.}
 
-# Encounter Table 5-- RNGR_D
+# Encounter Table 5 -- RNGR_D
 {3250}{}{Red Ryder.}
 {3251}{}{Una tormenta de polvo}
 {3252}{}{Una manada de coyotes.}
@@ -423,7 +423,7 @@
 {3271}{}{Un terrible monstruo, La Fantasma.}
 {3272}{}{Deshidratacion}
 
-# Encounter Table 6-- DSRT_A
+# Encounter Table 6 -- DSRT_A
 {3300}{}{Una tormenta de polvo}
 {3301}{}{Deshidratacion}
 {3302}{}{Una manada de escorpiones.}
@@ -441,7 +441,7 @@
 {3314}{}{Una fortaleza movil.}
 {3315}{}{Legend City.}
 
-# Encounter Table 7-- DSRT_B
+# Encounter Table 7 -- DSRT_B
 {3350}{}{Una tormenta de polvo}
 {3351}{}{Deshidratacion}
 {3352}{}{Una manada de escorpiones.}
@@ -461,7 +461,7 @@
 {3366}{}{Legend City.}
 {3367}{}{Un vehículo accidentado.}
 
-# Encounter Table 8-- MEXI_D
+# Encounter Table 8 -- MEXI_D
 {3400}{}{Red Ryder.}
 {3401}{}{Una manada de escorpiones.}
 {3402}{}{Un enjambre de mantis.}
@@ -483,7 +483,7 @@
 {3418}{}{Legend City.}
 {3419}{}{Un mexicano y un ciempiés.}
 
-# Encounter Table 9-- MEXI_M
+# Encounter Table 9 -- MEXI_M
 {3450}{}{Red Ryder.}
 {3451}{}{Un derrumbe}
 {3452}{}{Una manada de ratas topo.}
@@ -501,7 +501,7 @@
 {3464}{}{Legend City.}
 {3465}{}{Un brahman carnivoro.}
 
-# Encounter Table 10-- CALF_D
+# Encounter Table 10 -- CALF_D
 {3500}{}{Red Ryder.}
 {3501}{}{Niebla radiactiva}
 {3502}{}{Una manada de ratas.}
@@ -520,7 +520,7 @@
 {3515}{}{Una fortaleza movil.}
 {3516}{}{Legend City.}
 
-# Encounter Table 11-- PHNX_D
+# Encounter Table 11 -- PHNX_D
 {3550}{}{Red Ryder.}
 {3551}{}{Una manada de ratas.}
 {3552}{}{Una manada de perros.}
@@ -536,14 +536,14 @@
 {3562}{}{El Santuario Perdido.}
 {3563}{}{Legend City.}
 
-# Encounter Table 12-- PHNX_M
+# Encounter Table 12 -- PHNX_M
 {3600}{}{Niebla radiactiva}
 {3601}{}{Un grupo de hormigas gigantes.}
 {3602}{}{El cadaver de un merodeador.}
 {3603}{}{Un chatarrero solitario.}
 {3604}{}{Un robot enojado.}
 
-# Encounter Table 13-- ROAD_D
+# Encounter Table 13 -- ROAD_D
 {3650}{}{Red Ryder.}
 {3651}{}{Un cuerpo junto a la carretera.}
 {3652}{}{Una manada de ratas.}
@@ -557,7 +557,7 @@
 {3660}{}{El Santuario Perdido.}
 {3661}{}{Legend City.}
 
-# Encounter Table 14-- TUSN_D
+# Encounter Table 14 -- TUSN_D
 {3700}{}{Red Ryder.}
 {3701}{}{Una manada de ratas.}
 {3702}{}{Una manada de escorpiones.}
@@ -567,7 +567,7 @@
 {3706}{}{El cadaver de un esclavo fugitivo.}
 {3707}{}{Un cíborg.}
 
-# Encounter Table 15-- TUSN_M
+# Encounter Table 15 -- TUSN_M
 {3750}{}{Un derrumbe}
 {3751}{}{Una manada de ratas topo.}
 {3752}{}{Una manada de lobos.}
@@ -584,7 +584,7 @@
 {3763}{}{El Santuario Perdido.}
 {3764}{}{Legend City.}
 
-# Encounter Table 16-- INFN_D
+# Encounter Table 16 -- INFN_D
 {3800}{}{Niebla radiactiva}
 {3801}{}{Un grupo de hormigas gigantes.}
 {3802}{}{Un montón de chatarreros.}
@@ -592,7 +592,7 @@
 {3804}{}{Un agente de la USP.}
 {3805}{}{Harvey.}
 
-# Encounter Table 17-- PORT_D
+# Encounter Table 17 -- PORT_D
 {3850}{}{Red Ryder.}
 {3851}{}{Deshidratacion}
 {3852}{}{Algunas hormigas gigantes.}
@@ -600,7 +600,7 @@
 {3854}{}{Una manada de escorpiones.}
 {3855}{}{Una patrulla de la Hermandad.}
 
-# Encounter Table 18-- ISLD_D
+# Encounter Table 18 -- ISLD_D
 {3900}{}{Unas hormigas gigantes explorando la costa.}
 {3901}{}{Un monstruo.}
 {3902}{}{Un cadaver en la costa.}
@@ -608,7 +608,7 @@
 {3904}{}{El cuerpo de un explorador.}
 {3905}{}{Unos saqueadores y un escriba.}
 
-# Encounter Table 19-- ISLD_M
+# Encounter Table 19 -- ISLD_M
 {3950}{}{Un derrumbe}
 {3951}{}{Niebla radiactiva}
 {3952}{}{Un grupo de hormigas gigantes.}
@@ -625,5 +625,5 @@
 {3963}{}{El Padre volador.}
 {3964}{}{Legend City.}
 
-# Encounter Table 20-- OCEAN_O
+# Encounter Table 20 -- OCEAN_O
 {4000}{}{Niebla radiactiva}


### PR DESCRIPTION
* Fixed typo in `PCMaster.msg`.
* Fixed missing female line in `VCOld.msg`.
* Fixed Rat God's combat shout for Spanish.
* Unified the comment formatting in msg files according to [ScanMsg](https://github.com/wipe2238/ScanMsg) results (should start with hash sign).